### PR TITLE
[ENG-161] [ENG-163] v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skipjs
 
-A util for signing and sending bundles through the Skip sentinel.
+A util for signing and sending bundles through the Skip relayer.
 
 # Usage
 
@@ -15,10 +15,12 @@ export type SignedBundle = {
   signature: string
 }
 
-async signBundle(transactions: Array<TxRaw>, signer: OfflineSigner, signerAddress: string): SignedBundle
+async signBundle(transactions: Array<TxRaw>, signer: OfflineSigner, signerAddress: string): Promise<SignedBundle>
 
-async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean): Promise<object>
+async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean)
 ```
+
+
 
 Example usage:
 Import `SkipBundleClient`, as well as a way to get an `OfflineSigner`, and other utils for the chain you're using. For this example, we'll use Juno.
@@ -78,10 +80,10 @@ const txRaw = await client.sign(address, [msg], fee, '', {
 ```
 Create your SkipBundleClient:
 ```
-const skipBundleClient = new SkipBundleClient(SENTINEL_RPC_ENDPOINT)
+const skipBundleClient = new SkipBundleClient(RELAYER_RPC_ENDPOINT)
 ```
 
-The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](https://www.notion.so/skip-protocol/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c).
+The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip relayer endpoints for each chain can be found [here](https://www.notion.so/skip-protocol/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c).
 
 Sign and send your bundle:
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It returns a `SignedBundle`, which can be passed to `sendBundle` to send the bun
 
 `sendBundle` sends a `SignedBundle` to the relayer.
 `desiredHeight` is the desired height for the bundle to be included on-chain. Submitted bundles will only be considered in the auction for this height. Passing `0` as `desiredHeight` will cause the relayer to consider the bundle for the immediate next height.
-`sync` is an optional parameter that defaults to `false`. If set to `true`, the promise will not resolve until the bundle has been simulated. If set to `false`, the promise resolves on bundle submission, prior to its simulation.
+`sync` specifies whether to use the async or sync RPC endpoint. If set to `true`, the promise will not resolve until the bundle has been simulated. If set to `false`, the promise resolves on bundle submission, prior to its simulation.
 
 ## Example usage:
 Import `SkipBundleClient`, as well as a way to get an `OfflineSigner`, and other utils for the chain you're using. For this example, we'll use Juno.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ export type SignedBundle = {
   signature: string
 }
 
-async sendBundle(bundle: SignedBundle, desiredHeight: number) -> SignedBundle
+async signBundle(transactions: Array<TxRaw>, signer: OfflineSigner, signerAddress: string): SignedBundle
 
-asyncsendBundle(bundle: SignedBundle, desiredHeight: number) -> object
+async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean): Promise<object>
 ```
 
 Example usage:

--- a/README.md
+++ b/README.md
@@ -9,20 +9,28 @@ skipjs exposes a single default export, `SkipBundleClient`.
 `signBundle` and `sendBundle`.
 
 ```
-export type SignedBundle = {
+type SignedBundle = {
   transactions: Array<string>
   pubKey: string
   signature: string
 }
 
-async signBundle(transactions: Array<TxRaw>, signer: OfflineSigner, signerAddress: string): Promise<SignedBundle>
+async signBundle(transactions: Array<TxRaw>, signer: OfflineSigner, signerAddress: string): SignedBundle
 
-async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean)
+async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean): Promise<object>
 ```
 
+## signBundle
+`signBundle` is used to sign a bundle of transactions. It must be provided with an array of `TxRaw` (from cosmjs-types), an `OfflineSigner` (from cosmjs), and a `signerAddress` (the address of the searcher).
+It returns a `SignedBundle`, which can be passed to `sendBundle` to send the bundle to the relayer.
 
+## sendBundle
 
-Example usage:
+`sendBundle` sends a `SignedBundle` to the relayer.
+`desiredHeight` is the desired height for the bundle to be included on-chain. Submitted bundles will only be considered in the auction for this height. Passing `0` as `desiredHeight` will cause the relayer to consider the bundle for the immediate next height.
+`sync` is an optional parameter that defaults to `false`. If set to `true`, the promise will not resolve until the bundle has been simulated. If set to `false`, the promise resolves on bundle submission, prior to its simulation.
+
+## Example usage:
 Import `SkipBundleClient`, as well as a way to get an `OfflineSigner`, and other utils for the chain you're using. For this example, we'll use Juno.
 ```
 import { SkipBundleClient } from '@skip-mev/skipjs'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skip-mev/skipjs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@skip-mev/skipjs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@cosmjs/amino": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-mev/skipjs",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "exports": {
     ".": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,15 @@ export class SkipBundleClient {
     this.sentinelRPCEndpoint = sentinelRPCEndpoint
   }
 
-  public async sendBundle(bundle: SignedBundle, desiredHeight: number) {
+  public async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean) {
+      let method = 'broadcast_bundle_async'
+      if (sync) {
+          method = 'broadcast_bundle_sync'
+      }
+
     // Form request data
     const data = {
-        'method': 'broadcast_bundle_sync',
+        'method': method,
         'params': [bundle.transactions, desiredHeight.toString(), bundle.pubKey, bundle.signature],
         'id': 1
     }
@@ -29,7 +34,7 @@ export class SkipBundleClient {
         body: JSON.stringify(data)
     })
 
-    return response.json();
+    return response.json()
   }
 
   public async signBundle(transactions: Array<TxRaw>, signer: OfflineSigner, signerAddress: string) {
@@ -55,11 +60,11 @@ export class SkipBundleClient {
 async function helperSignBundle(txs: Uint8Array[], signer: OfflineSigner, signerAddress: string) {
     // @ts-ignore
     const accounts = await signer.getAccountsWithPrivkeys(); 
-    const account = accounts.find(({address} : {address:string}) => address === signerAddress);
+    const account = accounts.find(({address} : {address:string}) => address === signerAddress)
     if (account === undefined) {
-        throw new Error(`No account found for signer address ${signerAddress}`);
+        throw new Error(`No account found for signer address ${signerAddress}`)
     }
-    const { privkey, pubkey } = account;
+    const { privkey, pubkey } = account
     const hashedBundle = sha256(flatten(txs))
     const signature = await Secp256k1.createSignature(hashedBundle, privkey)
     const signatureBytes = new Uint8Array([...signature.r(32), ...signature.s(32)])
@@ -71,16 +76,16 @@ async function helperSignBundle(txs: Uint8Array[], signer: OfflineSigner, signer
 }
 
 function flatten(arr: Uint8Array[]): Uint8Array {
-    let totalLength = arr.reduce((acc, value) => acc + value.length, 0);
-    let result = new Uint8Array(totalLength);
+    let totalLength = arr.reduce((acc, value) => acc + value.length, 0)
+    let result = new Uint8Array(totalLength)
 
     let length = 0;
     for (let a of arr) {
-        result.set(a, length);
-        length += a.length;
+        result.set(a, length)
+        length += a.length
     }
 
-    return result;
+    return result
 }
 
 export type SignedBundle = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export class SkipBundleClient {
     return response.json()
   }
 
-  public async signBundle(transactions: Array<TxRaw>, signer: OfflineSigner, signerAddress: string) {
+  public async signBundle(transactions: Array<TxRaw>, signer: OfflineSigner, signerAddress: string): Promise<SignedBundle> {
     const transactionsToSign = []
     const b64Transactions = []
     for (let transaction of transactions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export class SkipBundleClient {
     this.sentinelRPCEndpoint = sentinelRPCEndpoint
   }
 
-  public async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean) {
+  public async sendBundle(bundle: SignedBundle, desiredHeight: number, sync: boolean) {
       let method = 'broadcast_bundle_async'
       if (sync) {
           method = 'broadcast_bundle_sync'


### PR DESCRIPTION
2 changes for v1.1.0:
1. We're no longer using the protobuf bundle encoding for signature verication, now just using a flat byte array of the txs.
2. We add the sync optional parameter to sendBundle