### PR TITLE
[ENG-218] Remove dependence on OfflineSigner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skip-mev/skipjs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@skip-mev/skipjs",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@cosmjs/amino": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-mev/skipjs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "exports": {
     ".": {


### PR DESCRIPTION
With this change, `signBundle` no longer takes in an `OfflineSigner`, it now just takes a private key directly.
This means it's up to the caller to create their own secp256k1 private key. Readme is updated with an example on how to do that with an OfflineSigner.
But this also means if you have your own private key or another way to generate one, you don't have to use cosmjs utils to do it.