### PR TITLE
[ENG-277] Accept arbitrary base64 strings as txs in bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ type SignedBundle = {
   signature: string
 }
 
-async signBundle(transactions: Array<string>, privKey: Uint8Array): SignedBundle
+async signBundle(transactions: string[], privKey: Uint8Array): SignedBundle
 
 async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean): Promise<object>
 ```

--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@ type SignedBundle = {
   signature: string
 }
 
-async signBundle(transactions: Array<TxRaw>, privKey: Uint8Array): SignedBundle
+async signBundle(transactions: Array<string>, privKey: Uint8Array): SignedBundle
 
 async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean): Promise<object>
 ```
 
 ## signBundle
-`signBundle` is used to sign a bundle of transactions. It must be provided with an array of `TxRaw` (from cosmjs-types) and a sepc256k1 private key, used to sign the bundle.
-It returns a `SignedBundle`, which can be passed to `sendBundle` to send the bundle to the relayer.
+`signBundle` is used to sign a bundle of transactions. It must be provided with an array of `string`, and a sepc256k1 private key, used to sign the bundle.
+The transactions argument should be an array of base64-encoded transaction strings. The encoded bytes can be either Cosmos SDK `TxRaw`s or Ethereum native transactions (such as those produced from `ethers`, for Ethermint EVM chains. See the examples for more details.
+`signBundle` returns a `SignedBundle`, which can be passed to `sendBundle` to send the bundle to the relayer.
 
 ## sendBundle
 
@@ -88,6 +89,11 @@ const txRaw = await client.sign(address, [msg], fee, '', {
 })
 ```
 
+Convert your TxRaw into a base64 string:
+```
+const txString = Buffer.from(txRaw).toString('base64')
+```
+
 Get the secp256k1 private key for signing the bundle.
 For example, this can be done with the cosmjs-utils offline signer:
 ```
@@ -103,7 +109,7 @@ The RPC endpoint is an `ip:port` string that depends on the chain you're using. 
 
 Sign and send your bundle:
 ```
-const signedBundle = await skipBundleClient.signBundle([txRaw], privKey)
+const signedBundle = await skipBundleClient.signBundle([txString], privKey)
 const sendBundle = await skipBundleClient.sendBundle(signedBundle, DESIRED_HEIGHT_FOR_BUNDLE, true)
 ```
 

--- a/examples/evmos.js
+++ b/examples/evmos.js
@@ -1,0 +1,43 @@
+// How to interact with an EVM contract in a Skip bundle
+
+import { SkipBundleClient } from '@skip-mev/skipjs'
+import ethers from 'ethers'
+import fs from 'fs'
+
+const MNEMONIC = "MNEMONIC"
+const RELAYER_RPC_ENDPOINT = "RELAYER_RPC_ENDPOINT"
+
+// Testnet RPC
+const provider = new ethers.providers.JsonRpcProvider("https://eth.bd.evmos.dev:8545");
+
+// EVM Contract info
+const bytecode = fs.readFileSync('storage.bin').toString();
+const abi = JSON.parse(fs.readFileSync('storage.abi').toString());
+
+// Get eth account from mnemonic
+const ethwallet = ethers.Wallet.fromMnemonic(trader1.mnemonic);
+const account = ethwallet.connect(provider);
+
+// Make contract instance
+const myContract = new ethers.ContractFactory(abi, bytecode, account);
+const contractInstance = new ethers.Contract("CONTRACT ADDRESS", abi, account);
+
+// Create the unsigned ethers transaction (replace "function" with contract function, populate gasLimit, gasPrice, nonce as appropriate)
+const unsignedTx = await contractInstance.populateTransaction.function({gasLimit: 50000, gasPrice: 15000000, nonce: 0});
+// Set the chainID according to evmos, this is using testnet
+unsignedTx.chainId = 9000
+
+// Sign the transaction
+const signedTx = await account.signTransaction(unsignedTx);
+
+// Convert the 0x-prefixed signedTx from hex-encoded to base64-encoded
+const b64Tx = Buffer.from(signedTx.slice(2), 'hex').toString('base64');
+
+// Provide any other txs in the bundle, and a private key to sign the bundle
+const skipBundleClient = new SkipBundleClient(RELAYER_RPC_ENDPOINT);
+const signedBundle = await skipBundleClient.signBundle([b64Tx, otherTx], privKey);
+
+// Send the bundle to the relayer
+const sendBundle = skipBundleClient.sendBundle(signedBundle, 0, true).then((res) => {
+  console.log(res);
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "@skip-mev/skipjs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@skip-mev/skipjs",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@cosmjs/amino": "^0.29.0",
         "@cosmjs/crypto": "^0.29.0",
-        "@cosmjs/proto-signing": "^0.29.0",
-        "cosmjs-types": "^0.5.1",
         "node-fetch-commonjs": "^3.2.4"
+      },
+      "devDependencies": {
+        "@types/node": "^18.11.9"
       }
     },
     "node_modules/@cosmjs/amino": {
@@ -59,20 +60,6 @@
         "bn.js": "^5.2.0"
       }
     },
-    "node_modules/@cosmjs/proto-signing": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.0.tgz",
-      "integrity": "sha512-zAdgDz5vRGAfJ5yyKYuTL7qg5UNUT7v4iV1/ZP8ZQn2fLh9QVxViAIovF4r/Y3EEI4JS5uYj/f8UeHMHQSu8hw==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.29.0",
-        "@cosmjs/crypto": "^0.29.0",
-        "@cosmjs/encoding": "^0.29.0",
-        "@cosmjs/math": "^0.29.0",
-        "@cosmjs/utils": "^0.29.0",
-        "cosmjs-types": "^0.5.0",
-        "long": "^4.0.0"
-      }
-    },
     "node_modules/@cosmjs/utils": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.0.tgz",
@@ -89,69 +76,11 @@
         }
       ]
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-    },
     "node_modules/@types/node": {
-      "version": "18.8.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA=="
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -186,15 +115,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-    },
-    "node_modules/cosmjs-types": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.5.1.tgz",
-      "integrity": "sha512-NcC58xUIVLlKdIimWWQAmSlmCjiMrJnuHf4i3LiD8PCextfHR0fT3V5/WlXZZreyMgdmh6ML1zPUfGTbbo3Z5g==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -285,11 +205,6 @@
         "libsodium": "^0.7.0"
       }
     },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -332,31 +247,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
       }
     },
     "node_modules/readonly-date": {
@@ -417,20 +307,6 @@
         "bn.js": "^5.2.0"
       }
     },
-    "@cosmjs/proto-signing": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.0.tgz",
-      "integrity": "sha512-zAdgDz5vRGAfJ5yyKYuTL7qg5UNUT7v4iV1/ZP8ZQn2fLh9QVxViAIovF4r/Y3EEI4JS5uYj/f8UeHMHQSu8hw==",
-      "requires": {
-        "@cosmjs/amino": "^0.29.0",
-        "@cosmjs/crypto": "^0.29.0",
-        "@cosmjs/encoding": "^0.29.0",
-        "@cosmjs/math": "^0.29.0",
-        "@cosmjs/utils": "^0.29.0",
-        "cosmjs-types": "^0.5.0",
-        "long": "^4.0.0"
-      }
-    },
     "@cosmjs/utils": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.0.tgz",
@@ -441,69 +317,11 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
       "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A=="
     },
-    "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    },
-    "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    },
-    "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    },
-    "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    },
-    "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
-    "@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-    },
     "@types/node": {
-      "version": "18.8.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA=="
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -524,15 +342,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-    },
-    "cosmjs-types": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.5.1.tgz",
-      "integrity": "sha512-NcC58xUIVLlKdIimWWQAmSlmCjiMrJnuHf4i3LiD8PCextfHR0fT3V5/WlXZZreyMgdmh6ML1zPUfGTbbo3Z5g==",
-      "requires": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
     },
     "elliptic": {
       "version": "6.5.4",
@@ -609,11 +418,6 @@
         "libsodium": "^0.7.0"
       }
     },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -636,26 +440,6 @@
       "requires": {
         "formdata-polyfill": "^4.0.10",
         "web-streams-polyfill": "^3.1.1"
-      }
-    },
-    "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
       }
     },
     "readonly-date": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-mev/skipjs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "exports": {
     ".": {
@@ -41,8 +41,9 @@
   "dependencies": {
     "@cosmjs/amino": "^0.29.0",
     "@cosmjs/crypto": "^0.29.0",
-    "@cosmjs/proto-signing": "^0.29.0",
-    "cosmjs-types": "^0.5.1",
     "node-fetch-commonjs": "^3.2.4"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.9"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
-import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 import fetch from 'node-fetch-commonjs'
 import { sha256, Secp256k1 } from '@cosmjs/crypto'
 import { encodeSecp256k1Signature } from "@cosmjs/amino"
-import  minimal_1 from "protobufjs/minimal.js"
 
 export class SkipBundleClient {
   private sentinelRPCEndpoint: string
@@ -19,16 +17,16 @@ export class SkipBundleClient {
 
     // Form request data
     const data = {
-        'method': method,
-        'params': [bundle.transactions, desiredHeight.toString(), bundle.pubKey, bundle.signature],
-        'id': 1
+      'method': method,
+      'params': [bundle.transactions, desiredHeight.toString(), bundle.pubKey, bundle.signature],
+      'id': 1
     }
 
     // Use the web endpoint to send the request
     const response = await fetch(this.sentinelRPCEndpoint, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify(data)
     })
@@ -36,49 +34,43 @@ export class SkipBundleClient {
     return response.json()
   }
 
-  public async signBundle(transactions: Array<TxRaw>, privKey: Uint8Array): Promise<SignedBundle> {
-    const transactionsToSign = []
-    const b64Transactions = []
+  public async signBundle(transactions: string[], privKey: Uint8Array): Promise<SignedBundle> {
+    const txBuffers = []
     for (let transaction of transactions) {
-      // Proto-encode tx
-      const txBytes = TxRaw.encode(transaction).finish()
-      transactionsToSign.push(txBytes)
-
-      // Base64 string encode the proto encoding
-      b64Transactions.push(Buffer.from(txBytes).toString('base64'))
+      txBuffers.push(Buffer.from(transaction, 'base64'))
     }
-    const signedBundle = await helperSignBundle(transactionsToSign, privKey);
+    const signedBundle = await helperSignBundle(txBuffers, privKey);
     return {
-        transactions: b64Transactions,
-        pubKey: signedBundle.pubKey,
-        signature: signedBundle.signature
+      transactions: transactions,
+      pubKey: signedBundle.pubKey,
+      signature: signedBundle.signature
     }
   }
 }
 
 async function helperSignBundle(txs: Uint8Array[], privKey: Uint8Array) {
-    const { privkey, pubkey } = await Secp256k1.makeKeypair(privKey)
-    const hashedBundle = sha256(flatten(txs))
-    const signature = await Secp256k1.createSignature(hashedBundle, privkey)
-    const signatureBytes = new Uint8Array([...signature.r(32), ...signature.s(32)])
-    const stdSignature = encodeSecp256k1Signature(Secp256k1.compressPubkey(pubkey), signatureBytes)
-    return {
-        signature: stdSignature.signature,
-        pubKey: stdSignature.pub_key.value
-    }
+  const { privkey, pubkey } = await Secp256k1.makeKeypair(privKey)
+  const hashedBundle = sha256(flatten(txs))
+  const signature = await Secp256k1.createSignature(hashedBundle, privkey)
+  const signatureBytes = new Uint8Array([...signature.r(32), ...signature.s(32)])
+  const stdSignature = encodeSecp256k1Signature(Secp256k1.compressPubkey(pubkey), signatureBytes)
+  return {
+    signature: stdSignature.signature,
+    pubKey: stdSignature.pub_key.value
+  }
 }
 
 function flatten(arr: Uint8Array[]): Uint8Array {
-    let totalLength = arr.reduce((acc, value) => acc + value.length, 0)
-    let result = new Uint8Array(totalLength)
+  let totalLength = arr.reduce((acc, value) => acc + value.length, 0)
+  let result = new Uint8Array(totalLength)
 
-    let length = 0;
-    for (let a of arr) {
-        result.set(a, length)
-        length += a.length
-    }
+  let length = 0;
+  for (let a of arr) {
+    result.set(a, length)
+    length += a.length
+  }
 
-    return result
+  return result
 }
 
 export type SignedBundle = {


### PR DESCRIPTION
- `signBundle` now accepts arbitrary base64 strings so that it can accept any type of tx bytes, not just cosmjs `TxRaw`. This means Ethereum txes must be decoded from hex and re-encoded with base64.
- Update readme, add evmos Ethereum contract example
- Fix indentation inconsistencies
- Remove unused dependencies

Tested by sending ethereum txs in bundles on Evmos testnet