### PR TITLE
[ENG-391] Add skip secure support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # skipjs
 
-A util for signing and sending bundles through the Skip relayer.
+A util for 
+
+1. Signing and sending bundles
+2. Sending secure transactions
+
+through the Skip Sentinel.
 
 # Usage
 
-skipjs exposes a single default export, `SkipBundleClient`.
+For signing and sending bundles, skipjs exposes a single default export, `SkipBundleClient`.
 `SkipBundleClient` has two functions:
 `signBundle` and `sendBundle`.
 
@@ -20,16 +25,24 @@ async signBundle(transactions: string[], privKey: Uint8Array): SignedBundle
 async sendBundle(bundle: SignedBundle, desiredHeight: number, sync?: boolean): Promise<object>
 ```
 
+For sending secure transactions, skipjs exposes an export, `SkipSecureClient`, with a single function: `sendSecureTransaction`.
+```
+async sendSecureTransaction(transaction: string)
+```
+
+# SkipBundleClient
+
 ## signBundle
 `signBundle` is used to sign a bundle of transactions. It must be provided with an array of `string`, and a sepc256k1 private key, used to sign the bundle.
 The transactions argument should be an array of base64-encoded transaction strings. The encoded bytes can be either Cosmos SDK `TxRaw`s or Ethereum native transactions (such as those produced from `ethers`, for Ethermint EVM chains. See the examples for more details.
-`signBundle` returns a `SignedBundle`, which can be passed to `sendBundle` to send the bundle to the relayer.
+`signBundle` returns a `SignedBundle`, which can be passed to `sendBundle` to send the bundle to the Sentinel.
 
 ## sendBundle
 
-`sendBundle` sends a `SignedBundle` to the relayer.
-`desiredHeight` is the desired height for the bundle to be included on-chain. Submitted bundles will only be considered in the auction for this height. Passing `0` as `desiredHeight` will cause the relayer to consider the bundle for the immediate next height.
+`sendBundle` sends a `SignedBundle` to the Sentinel.
+`desiredHeight` is the desired height for the bundle to be included on-chain. Submitted bundles will only be considered in the auction for this height. Passing `0` as `desiredHeight` will cause the Sentinel to consider the bundle for the immediate next height.
 `sync` specifies whether to use the async or sync RPC endpoint. If set to `true`, the promise will not resolve until the bundle has been simulated. If set to `false`, the promise resolves on bundle submission, prior to its simulation.
+
 
 ## Example usage:
 Import `SkipBundleClient`, as well as a way to get an sepc256k1 private key, and other utils for the chain you're using. For this example, we'll use Juno.
@@ -103,15 +116,98 @@ const privKey = (await signer.getAccountsWithPrivkeys())[0].privkey
 
 Create your SkipBundleClient:
 ```
-const skipBundleClient = new SkipBundleClient(RELAYER_RPC_ENDPOINT)
+const skipBundleClient = new SkipBundleClient(SENTINEL_RPC_ENDPOINT)
 ```
 
-The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip relayer endpoints for each chain can be found [here](https://www.notion.so/skip-protocol/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c).
+The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](https://www.notion.so/skip-protocol/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c).
 
 Sign and send your bundle:
 ```
 const signedBundle = await skipBundleClient.signBundle([txString], privKey)
-const sendBundle = await skipBundleClient.sendBundle(signedBundle, DESIRED_HEIGHT_FOR_BUNDLE, true)
+const sendBundleResponse = await skipBundleClient.sendBundle(signedBundle, DESIRED_HEIGHT_FOR_BUNDLE, true)
 ```
 
-`DESIRED_HEIGHT_FOR_BUNDLE` should be a number, where 0 asks the relayer to autodetermine the next height.
+`DESIRED_HEIGHT_FOR_BUNDLE` should be a number, where 0 asks the Sentinel to autodetermine the next height.
+
+# SkipSecureClient
+
+## sendSecureTransaction
+`sendSecureTransaction` is used to send transactions privately to the Skip Sentinel to keep the transaction hidden from the public mempool. The Sentinel attempts to privately send the transaction to the a Skip proposer for 5 minutes until discarding the transaction. It takes a single transaction, where the memo of the transaction must be equal to the sender's address.
+
+## Example usage:
+
+Import `SkipSecureClient`, as well as other utils for generating transactions for the chain you're using. For this example, we'll use Juno.
+```
+import { SkipSecureClient } from '@skip-mev/skipjs'
+import { getOfflineSignerProto } from 'cosmjs-utils'
+import { juno, getSigningCosmosClient, cosmos } from 'juno-network'
+import { chains } from 'chain-registry'
+```
+Create your transactions:
+```
+const {
+    multiSend,
+    send
+} = cosmos.bank.v1beta1.MessageComposer.fromPartial
+
+var msg = send({
+    amount: [
+    {
+        denom: 'ujuno',
+        amount: '10'
+    }
+    ],
+    toAddress: toAddress,
+    fromAddress: fromAddress
+})
+
+const fee = {
+    amount: [
+    {
+        denom: 'ujuno',
+        amount: '864'
+    }
+    ],
+    gas: '86364'
+}
+```
+
+Sign your transactions. Note that the memo of the transaction must be the same as the sender address in order to be accepted by the Sentinel.
+```
+const mnemonic = "" // Insert your mnemonic
+const signer = await getOfflineSignerProto({
+    mnemonic,
+    chain: chains.find(({ chain_name }) => chain_name === 'juno')
+})
+
+const client = await getSigningCosmosClient({
+  rpcEndpoint,
+  signer
+})
+
+const { accountNumber, sequence } = await client.getSequence(address);
+// Note that we use the address for the memo.
+const txRaw = await client.sign(address, [msg], fee, address, {
+    accountNumber: accountNumber,
+    sequence: sequence,
+    chainId: 'juno-1'
+})
+```
+
+Convert your TxRaw into a base64 string:
+```
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
+const txString = Buffer.from(TxRaw.encode(txRaw).finish()).toString('base64')
+```
+
+Create your SkipSecureClient:
+```
+const skipSecureClient = new SkipSecureClient(SENTINEL_RPC_ENDPOINT)
+```
+
+The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](https://www.notion.so/skip-protocol/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c).
+
+Send your secure transaction:
+```
+const sendSecureTransactionResponse = await skipSecureClient.sendSecureTransaction(txString)
+```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # skipjs
 
-A util for 
+A util for:
 
-1. Signing and sending bundles
-2. Sending secure transactions
-
-through the Skip Sentinel.
+1. Signing and sending bundles of atomic transactions for inclusion by validators participating in the [Skip Select blockspace market](docs.skip.money)
+2. Sending secure transactions through the [Skip Secure RPC](docs.skip.money/skip-secure-rpc) to avoid the public mempool
 
 # Usage
 
@@ -119,7 +117,7 @@ Create your SkipBundleClient:
 const skipBundleClient = new SkipBundleClient(SENTINEL_RPC_ENDPOINT)
 ```
 
-The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](https://www.notion.so/skip-protocol/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c).
+The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](docs.skip.money/chain-configuration).
 
 Sign and send your bundle:
 ```
@@ -132,7 +130,10 @@ const sendBundleResponse = await skipBundleClient.sendBundle(signedBundle, DESIR
 # SkipSecureClient
 
 ## sendSecureTransaction
-`sendSecureTransaction` is used to send transactions privately to the Skip Sentinel to keep the transaction hidden from the public mempool. The Sentinel attempts to privately send the transaction to the a Skip proposer for 5 minutes until discarding the transaction. It takes a single transaction, where the memo of the transaction must be equal to the sender's address.
+`sendSecureTransaction` is used to send transactions privately through the [Skip Secure RPC](docs.skip.money/skip-secure-rpc) to keep the transaction hidden from the public mempool. The Sentinel attempts to privately send the transaction to a proposer participating in Skip Select for 5 minutes until discarding the transaction: 
+
+1. It takes a single transaction
+2. The memo of the transaction must be equal to the sender's address
 
 ## Example usage:
 
@@ -205,7 +206,7 @@ Create your SkipSecureClient:
 const skipSecureClient = new SkipSecureClient(SENTINEL_RPC_ENDPOINT)
 ```
 
-The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](https://www.notion.so/skip-protocol/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c).
+The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](docs.skip.money/chain-configuration).
 
 Send your secure transaction:
 ```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A util for:
 
-1. Signing and sending bundles of atomic transactions for inclusion by validators participating in the [Skip Select blockspace market](docs.skip.money)
-2. Sending secure transactions through the [Skip Secure RPC](docs.skip.money/skip-secure-rpc) to avoid the public mempool
+1. Signing and sending bundles of transactions to the [Skip Select auction](https://docs.skip.money)
+2. Sending secure transactions through the [Skip Secure RPC](https://docs.skip.money/skip-secure-rpc) to avoid the public mempool
 
 # Usage
 
@@ -117,7 +117,7 @@ Create your SkipBundleClient:
 const skipBundleClient = new SkipBundleClient(SENTINEL_RPC_ENDPOINT)
 ```
 
-The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](docs.skip.money/chain-configuration).
+The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](https://docs.skip.money/chain-configuration).
 
 Sign and send your bundle:
 ```
@@ -130,7 +130,7 @@ const sendBundleResponse = await skipBundleClient.sendBundle(signedBundle, DESIR
 # SkipSecureClient
 
 ## sendSecureTransaction
-`sendSecureTransaction` is used to send transactions privately through the [Skip Secure RPC](docs.skip.money/skip-secure-rpc) to keep the transaction hidden from the public mempool. The Sentinel attempts to privately send the transaction to a proposer participating in Skip Select for 5 minutes until discarding the transaction: 
+`sendSecureTransaction` is used to send transactions privately through the [Skip Secure RPC](https://docs.skip.money/skip-secure-rpc) to keep the transaction hidden from the public mempool. The Sentinel attempts to privately send the transaction to a proposer participating in Skip Select for 5 minutes until discarding the transaction: 
 
 1. It takes a single transaction
 2. The memo of the transaction must be equal to the sender's address
@@ -206,7 +206,7 @@ Create your SkipSecureClient:
 const skipSecureClient = new SkipSecureClient(SENTINEL_RPC_ENDPOINT)
 ```
 
-The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](docs.skip.money/chain-configuration).
+The RPC endpoint is an `ip:port` string that depends on the chain you're using. Skip Sentinel endpoints for each chain can be found [here](https://docs.skip.money/chain-configuration).
 
 Send your secure transaction:
 ```

--- a/examples/evmos.js
+++ b/examples/evmos.js
@@ -5,7 +5,7 @@ import ethers from 'ethers'
 import fs from 'fs'
 
 const MNEMONIC = "MNEMONIC"
-const RELAYER_RPC_ENDPOINT = "RELAYER_RPC_ENDPOINT"
+const SENTINEL_RPC_ENDPOINT = "SENTINEL_RPC_ENDPOINT"
 
 // Testnet RPC
 const provider = new ethers.providers.JsonRpcProvider("https://eth.bd.evmos.dev:8545");
@@ -34,10 +34,10 @@ const signedTx = await account.signTransaction(unsignedTx);
 const b64Tx = Buffer.from(signedTx.slice(2), 'hex').toString('base64');
 
 // Provide any other txs in the bundle, and a private key to sign the bundle
-const skipBundleClient = new SkipBundleClient(RELAYER_RPC_ENDPOINT);
+const skipBundleClient = new SkipBundleClient(SENTINEL_RPC_ENDPOINT);
 const signedBundle = await skipBundleClient.signBundle([b64Tx, otherTx], privKey);
 
-// Send the bundle to the relayer
+// Send the bundle to the sentinel
 const sendBundle = skipBundleClient.sendBundle(signedBundle, 0, true).then((res) => {
   console.log(res);
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-mev/skipjs",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-mev/skipjs",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "",
   "exports": {
     ".": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export class SkipSecureClient {
   public async sendSecureTransaction(transaction: string) {
     // Form request data
     const data = {
-      'method': 'broadcast_secure_tx',
+      'method': 'broadcast_tx_sync',
       'params': [transaction],
       'id': 1
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,11 @@ export class SkipBundleClient {
 
     // Use the web endpoint to send the request
     const response = await fetch(this.sentinelRPCEndpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(data)
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(data)
     })
 
     return response.json()
@@ -45,6 +45,34 @@ export class SkipBundleClient {
       pubKey: signedBundle.pubKey,
       signature: signedBundle.signature
     }
+  }
+}
+
+export class SkipSecureClient {
+  private sentinelRPCEndpoint: string
+
+  constructor(sentinelRPCEndpoint: string) {
+    this.sentinelRPCEndpoint = sentinelRPCEndpoint
+  }
+
+  public async sendSecureTransaction(transaction: string) {
+    // Form request data
+    const data = {
+      'method': 'broadcast_secure_tx',
+      'params': [transaction],
+      'id': 1
+    }
+
+    // Use the web endpoint to send the request
+    const response = await fetch(this.sentinelRPCEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(data)
+    })
+
+    return response.json()
   }
 }
 


### PR DESCRIPTION
- Adds support for skip secure (`SkipSecureClient`)
- Rename relayer -> sentinel
- Update readme w/ skip secure stuff
- Bump version to 1.4.0