### PR TITLE
Add terra.js example to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,10 @@ const sendBundleResponse = await skipBundleClient.sendBundle(signedBundle, DESIR
 ```
 
 `DESIRED_HEIGHT_FOR_BUNDLE` should be a number, where 0 asks the Sentinel to autodetermine the next height.
-### Terra and others using terra.js / feather.js
-Terra and [alliance](https://github.com/terra-money/alliance) chains usually use an alternative client library called [terra.js](https://github.com/terra-money/terra.js), it was rebranded to [feather.js](https://github.com/terra-money/feather.js) in late 2022 to add multichain support (i.e. similar to cosmjs, you can use it to interact with not only terra but also other cosmos SDK chains, most likely alliance chains that share security with Terra).
-
+### Terra and [Alliance](https://github.com/terra-money/alliance) chains use an alternative client library called [feather.js](https://github.com/terra-money/feather.js).
 The overall logic is similar to using cosmjs. Modified from the [send native token example](https://docs.terra.money/develop/feather-js/common-examples#sending-native-tokens).
 
-Import skip and feather.
+Import Skip and feather.js.
 ```
 import { SkipBundleClient } from '@skip-mev/skipjs'
 import { LCDClient, MnemonicKey, MsgSend } from '@terra-money/feather.js'
@@ -163,23 +161,23 @@ const wallet = lcd.wallet(mk)
 const privKey = mk.privateKey
 ```
 
-Construct message of send token to your contact address and another send token to [skip auction house address](https://docs.skip.money/searcher#winning-the-auction).
+Construct message of sending token to your destination destination and another to [skip auction house address](https://docs.skip.money/searcher#winning-the-auction).
 ```
-const sendToYourContact = new MsgSend(
+const sendToYourDestination = new MsgSend(
   wallet.key.accAddress('terra'), // requires prefix as a parameter
-  'terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8',
+  'TO_ADDRESS',
   { uluna: '1000000' },
 )
 const sendToSkipAuctionHouse = new MsgSend(
   wallet.key.accAddress('terra'), // requires prefix as a parameter
-  'terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8', // replace this with skip auction house address on the corresponding chain and network
+  'SKIP_AUCTION_HOUSE_ADDRESS', // replace this with skip auction house address on the corresponding chain and network
   { uluna: '1000000' }, // amount you send to skip to bid your tx
 )
 ```
 
 Create the tx and convert it to base64 string.
 ```
-const tx = await wallet.createAndSignTx({ msgs: [send] })
+const tx = await wallet.createAndSignTx({ msgs: [sendToYourDestination, sendToSkipAuctionHouse] })
 const txString = Buffer.from(tx.toBytes()).toString('base64')
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ var msg = send({
     fromAddress: fromAddress
 })
 
+var msgToSkipAuctionHouse = send({
+    amount: [
+    {
+        denom: 'ujuno',
+        amount: '10'
+    }
+    ],
+    toAddress: skipAuctionHouseAddress,
+    fromAddress: fromAddress
+})
+
 const fee = {
     amount: [
     {
@@ -94,7 +105,7 @@ const client = await getSigningCosmosClient({
 })
 
 const { accountNumber, sequence } = await client.getSequence(address);
-const txRaw = await client.sign(address, [msg], fee, '', {
+const txRaw = await client.sign(address, [msg, msgToSkipAuctionHouse], fee, '', {
     accountNumber: accountNumber,
     sequence: sequence,
     chainId: 'juno-1'
@@ -152,13 +163,22 @@ const wallet = lcd.wallet(mk)
 const privKey = mk.privateKey
 ```
 
-Construct send token tx and convert it to base64 string.
+Construct message of send token to your contact address and another send token to [skip auction house address](https://docs.skip.money/searcher#winning-the-auction).
 ```
-const send = new MsgSend(
+const sendToYourContact = new MsgSend(
   wallet.key.accAddress('terra'), // requires prefix as a parameter
   'terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8',
   { uluna: '1000000' },
 )
+const sendToSkipAuctionHouse = new MsgSend(
+  wallet.key.accAddress('terra'), // requires prefix as a parameter
+  'terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8', // replace this with skip auction house address on the corresponding chain and network
+  { uluna: '1000000' }, // amount you send to skip to bid your tx
+)
+```
+
+Create the tx and convert it to base64 string.
+```
 const tx = await wallet.createAndSignTx({ msgs: [send] })
 const txString = Buffer.from(tx.toBytes()).toString('base64')
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The transactions argument should be an array of base64-encoded transaction strin
 
 
 ## Example usage:
+### Juno and others using cosmjs
 Import `SkipBundleClient`, as well as a way to get an sepc256k1 private key, and other utils for the chain you're using. For this example, we'll use Juno.
 ```
 import { SkipBundleClient } from '@skip-mev/skipjs'
@@ -126,7 +127,49 @@ const sendBundleResponse = await skipBundleClient.sendBundle(signedBundle, DESIR
 ```
 
 `DESIRED_HEIGHT_FOR_BUNDLE` should be a number, where 0 asks the Sentinel to autodetermine the next height.
+### Terra and others using terra.js / feather.js
+Terra and [alliance](https://github.com/terra-money/alliance) chains usually use an alternative client library called [terra.js](https://github.com/terra-money/terra.js), it was rebranded to [feather.js](https://github.com/terra-money/feather.js) in late 2022 to add multichain support (i.e. similar to cosmjs, you can use it to interact with not only terra but also other cosmos SDK chains, most likely alliance chains that share security with Terra).
 
+The overall logic is similar to using cosmjs. Modified from the [send native token example](https://docs.terra.money/develop/feather-js/common-examples#sending-native-tokens).
+
+Import skip and feather.
+```
+import { SkipBundleClient } from '@skip-mev/skipjs'
+import { LCDClient, MnemonicKey, MsgSend } from '@terra-money/feather.js'
+```
+
+Create LCD and get mnemonic key.
+```
+const lcd = new LCDClient({
+    URL: LCD_ENDPOINT,
+    chainID: CHAIN_ID,
+})
+
+const mk = new MnemonicKey({
+  mnemonic:'', // Insert your mnemonic
+})
+const wallet = lcd.wallet(mk)
+const privKey = mk.privateKey
+```
+
+Construct send token tx and convert it to base64 string.
+```
+const send = new MsgSend(
+  wallet.key.accAddress('terra'), // requires prefix as a parameter
+  'terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8',
+  { uluna: '1000000' },
+)
+const tx = await wallet.createAndSignTx({ msgs: [send] })
+const txString = Buffer.from(tx.toBytes()).toString('base64')
+```
+
+Create skip client and send your bundle!
+```
+const skipBundleClient = new SkipBundleClient(SENTINEL_RPC_ENDPOINT)
+const signedBundle = await skipBundleClient.signBundle([txString], privKey)
+return await skipBundleClient.sendBundle(signedBundle, DESIRED_HEIGHT_FOR_BUNDLE, true)
+```
+`DESIRED_HEIGHT_FOR_BUNDLE` should be a number, where 0 asks the Sentinel to autodetermine the next height.
 # SkipSecureClient
 
 ## sendSecureTransaction


### PR DESCRIPTION
Currently doc only has example using `cosmjs` with skip, since Terra is also integrated with Skip, adding a `terra.js` / `feather.js` example will be nice!